### PR TITLE
Change pan responder logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,12 +136,17 @@ const Swipeout = React.createClass({
     };
   },
 
+  _onMoveShouldSetPanResponder: function(event, gestureState) {
+    return Math.abs(gestureState.dx) > this.props.sensitivity;
+  },
+
   componentWillMount: function() {
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: (event, gestureState) => true,
       onMoveShouldSetPanResponder: (event, gestureState) =>
-        Math.abs(gestureState.dx) > this.props.sensitivity &&
-        Math.abs(gestureState.dy) > this.props.sensitivity,
+        this._onMoveShouldSetPanResponder(event, gestureState),
+      onMoveShouldSetPanResponderCapture: (event, gestureState) =>
+        this._onMoveShouldSetPanResponder(event, gestureState),
       onPanResponderGrant: this._handlePanResponderGrant,
       onPanResponderMove: this._handlePanResponderMove,
       onPanResponderRelease: this._handlePanResponderEnd,


### PR DESCRIPTION
- Instead of checking both x and y, just check x since we only care
  about movement along that dimension.
- Also implement the onMoveShouldSetPanResponderCapture to ensure that
  the swipeout is activated even if there’s a touchable child view.
